### PR TITLE
This fixes the removed MediaStream.stop() for chrome 47

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-footer": "^1.0.5",
     "gulp-header": "^1.0.5",
     "gulp-jshint": "^1.6.1",
+    "gulp-livereload": "^3.8.1",
     "gulp-sourcemaps": "^1.1.5",
     "gulp-uglify": "^0.3.0",
     "zuul": "^1.10.2"

--- a/src/qcode-decoder.js
+++ b/src/qcode-decoder.js
@@ -178,7 +178,7 @@ QCodeDecoder.prototype.decodeFromImage = function (img, cb) {
  */
 QCodeDecoder.prototype.stop = function() {
   if (this.stream) {
-    this.stream.stop();
+    this.stream.getTracks().forEach(function (track) { track.stop(); });
     this.stream = undefined;
   }
 


### PR DESCRIPTION
Mediastream.stop() is deprecated since Chrome 45 and does not work anymore with Chrome 47. This pull request fixes the issue in calling stop() for each track of the stream. Note you can reproduce the error with the capture example implementation of https://cirocosta.github.io/qcode-decoder/
