### PR TITLE
update stream.stop() call

### DIFF
--- a/src/qcode-decoder.js
+++ b/src/qcode-decoder.js
@@ -178,7 +178,7 @@ QCodeDecoder.prototype.decodeFromImage = function (img, cb) {
  */
 QCodeDecoder.prototype.stop = function() {
   if (this.stream) {
-    this.stream.stop();
+    this.stream.getTracks()[0].stop();
     this.stream = undefined;
   }
 


### PR DESCRIPTION
stream.stop()has been deprecated. In Chrome 55, this call produces an Uncaught TypeError: this.stream.stop is not a function.

This method call has been changed to the new syntax this.stream.getTracks()[0].stop().

This solves #43.