### PR TITLE
Fix .stop on chrome 47 and later

### DIFF
--- a/src/qcode-decoder.js
+++ b/src/qcode-decoder.js
@@ -178,7 +178,7 @@ QCodeDecoder.prototype.decodeFromImage = function (img, cb) {
  */
 QCodeDecoder.prototype.stop = function() {
   if (this.stream) {
-    this.stream.stop();
+    this.stream.getTracks().forEach(function (track) { track.stop(); });
     this.stream = undefined;
   }
 


### PR DESCRIPTION
"Uncaught TypeError: this.stream.stop is not a function"